### PR TITLE
Add basic support for stream storage in CAS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let package = Package(
             targets: ["TSFFutures", "TSFUtility"]),
         .library(
             name: "SwiftToolsSupportCAS",
-            targets: ["TSFCAS", "TSFCASFileTree"]),
+            targets: ["TSFCAS", "TSFCASFileTree", "TSFCASUtilities"]),
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.8.0"),
@@ -51,9 +51,19 @@ let package = Package(
                 "TSFFutures", "TSFUtility", "CBLAKE3", "SwiftProtobuf",
             ]
         ),
+        .target(
+            name: "TSFCASUtilities",
+            dependencies: [
+                "TSFCAS",
+            ]
+        ),
         .testTarget(
             name: "TSFCASTests",
             dependencies: ["TSFCAS"]
+        ),
+        .testTarget(
+            name: "TSFCASUtilitiesTests",
+            dependencies: ["TSFCASUtilities"]
         ),
         .target(
             name: "TSFCASFileTree",

--- a/Sources/TSFCASUtilities/LinkedListStream.swift
+++ b/Sources/TSFCASUtilities/LinkedListStream.swift
@@ -1,0 +1,110 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import TSCUtility
+import TSFCAS
+
+/// Basic writer implementation that resembles a linked list where each node contains control data (like the channel)
+/// and refs[0] always points to the dataID of the data chunk and refs[1] has the data ID for the next node in the
+/// chain, if it's not the last node. This implementation is not thread safe.
+public struct LLBLinkedListStreamWriter: LLBCASStreamWriter {
+    private let db: LLBCASDatabase
+
+    public private(set) var latestID: LLBFuture<LLBDataID>?
+
+    public init(_ db: LLBCASDatabase) {
+        self.db = db
+    }
+
+    @discardableResult
+    public mutating func append(data: LLBByteBuffer, channel: UInt8, _ ctx: Context) -> LLBFuture<LLBDataID> {
+        let latest = (
+            // Append on the previously cached node, or use nil as sentinel if this is the first write.
+            latestID?.map { $0 } ?? db.group.next().makeSucceededFuture(nil)
+        ).flatMap { [db] (currentDataID: LLBDataID?) -> LLBFuture<LLBDataID> in
+            db.put(data: data, ctx).flatMap { [db] contentID in
+                // Put the channel as the only byte in the control node.
+                let controlData = LLBByteBuffer.init(bytes: [channel])
+                // compactmap to remove the currentDataID in case it was the nil sentinel.
+                let refs: [LLBDataID] = [contentID, currentDataID].compactMap { $0 }
+                return db.put(refs: refs, data: controlData, ctx)
+            }
+        }
+
+        self.latestID = latest
+        return latest
+    }
+}
+
+public struct LLBLinkedListStreamReader: LLBCASStreamReader {
+    private let db: LLBCASDatabase
+
+    public init(_ db: LLBCASDatabase) {
+        self.db = db
+    }
+
+    public func read(
+        id: LLBDataID,
+        channels: [UInt8]?,
+        lastReadID: LLBDataID?,
+        _ ctx: Context,
+        readBlock: @escaping (UInt8, LLBByteBuffer) -> Bool
+    ) throws -> LLBFuture<Void> {
+        return innerRead(id: id, channels: channels, lastReadID: lastReadID, ctx, readBlock: readBlock).map { _ in () }
+    }
+
+    private func innerRead(
+        id: LLBDataID,
+        channels: [UInt8]? = nil,
+        lastReadID: LLBDataID? = nil,
+        _ ctx: Context,
+        readBlock: @escaping (UInt8, LLBByteBuffer) throws -> Bool
+    ) -> LLBFuture<Bool> {
+        if id == lastReadID {
+            return db.group.next().makeSucceededFuture(true)
+        }
+
+        return db.get(id, ctx).flatMap { node -> LLBFuture<Bool> in
+            guard let node = node, let channel = node.data.getBytes(at: 0, length: 1)?[0] else {
+                return db.group.next().makeFailedFuture(LLBCASStreamError.invalid)
+            }
+
+            let readChainFuture: LLBFuture<Bool>
+            // If there are 2 refs, it's an intermediate node in the linked list, so we schedule a read of the next
+            // node before scheduling a read of the current node.
+            if node.refs.count == 2 {
+                readChainFuture = innerRead(
+                    id: node.refs[1],
+                    channels: channels,
+                    lastReadID: lastReadID,
+                    ctx, readBlock: readBlock
+                )
+            } else {
+                // If this is the last node, schedule a sentinel read that returns to keep on reading.
+                readChainFuture = db.group.next().makeSucceededFuture(true)
+            }
+
+            return readChainFuture.flatMap { shouldContinue -> LLBFuture<Bool> in
+                // If we don't want to continue reading, or if the channel is not requested, close the current chain
+                // and propagate the desire to keep on reading.
+                guard shouldContinue && channels?.contains(channel) ?? true else {
+                    return db.group.next().makeSucceededFuture(shouldContinue)
+                }
+
+                // Read the node since it's expected to exist.
+                return db.get(node.refs[0], ctx).flatMapThrowing { (dataNode: LLBCASObject?) -> Bool in
+                    guard let dataNode = dataNode else {
+                        throw LLBCASStreamError.missing
+                    }
+
+                    return try readBlock(channel, dataNode.data)
+                }
+            }
+        }
+    }
+}

--- a/Sources/TSFCASUtilities/StreamProtocol.swift
+++ b/Sources/TSFCASUtilities/StreamProtocol.swift
@@ -1,0 +1,88 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import TSCUtility
+import TSFCAS
+
+/// The stream protocols provide an abstraction for reading and writing content that is generated from a stream (such
+/// as stdout/stderr) in a CAS efficient manner. The intention is that implementation of these procotols are designed
+/// to minimize storage structure as new data is appended, in order to minimize roundtrips to the CAS and maximize the
+/// immutability trait. The intention is not to force different implementations to be compatible, so stream stored under
+/// a particular writer implementation should be read with its matching reader implementation.
+
+/// Writer protocol for storing stream data.
+public protocol LLBCASStreamWriter {
+    var latestID: LLBFuture<LLBDataID>? { get }
+
+    /// Appends data into the stream data structure under the specified channel. Returns a future with the LLBDataID
+    /// to a valid stream data structure that can be read using a LLBCASStreamReader implementation.
+    @discardableResult
+    mutating func append(data: LLBByteBuffer, channel: UInt8, _ ctx: Context) -> LLBFuture<LLBDataID>
+}
+
+// Convenience extension for default parameters.
+public extension LLBCASStreamWriter {
+    @discardableResult
+    @inlinable
+    mutating func append(data: LLBByteBuffer, _ ctx: Context) -> LLBFuture<LLBDataID> {
+        return append(data: data, channel: 0, ctx)
+    }
+}
+
+/// Reader protocol for stored stream data.
+public protocol LLBCASStreamReader {
+    /// Reads from the stream pointed by the id parameter. If channels is not specified, it will read all the channels,
+    /// in the order they were appended, otherwise will only provide data from the specified channels. If lastReadID
+    /// is provided, the stream will start at the given ID, otherwise it will read from the beginning of the stream.
+    /// Read happens through the provided closure, which provides the data chunk along with the channel it was stored
+    /// under.
+    func read(
+        id: LLBDataID,
+        channels: [UInt8]?,
+        lastReadID: LLBDataID?,
+        _ ctx: Context,
+        readBlock: @escaping (UInt8, LLBByteBuffer) -> Bool
+    ) throws -> LLBFuture<Void>
+}
+
+// Convenience extension for default parameters.
+public extension LLBCASStreamReader {
+    @inlinable
+    func read(
+        id: LLBDataID,
+        _ ctx: Context,
+        readBlock: @escaping (UInt8, LLBByteBuffer) -> Bool
+    ) throws -> LLBFuture<Void> {
+        return try read(id: id, channels: nil, lastReadID: nil, ctx, readBlock: readBlock)
+    }
+
+    @inlinable
+    func read(
+        id: LLBDataID,
+        channels: [UInt8],
+        _ ctx: Context,
+        readBlock: @escaping (UInt8, LLBByteBuffer) -> Bool
+    ) throws -> LLBFuture<Void> {
+        return try read(id: id, channels: channels, lastReadID: nil, ctx, readBlock: readBlock)
+    }
+
+    @inlinable
+    func read(
+        id: LLBDataID,
+        lastReadID: LLBDataID,
+        _ ctx: Context,
+        readBlock: @escaping (UInt8, LLBByteBuffer) -> Bool
+    ) throws -> LLBFuture<Void> {
+        return try read(id: id, channels: nil, lastReadID: lastReadID, ctx, readBlock: readBlock)
+    }
+}
+
+public enum LLBCASStreamError: Error {
+    case invalid
+    case missing
+}

--- a/Tests/TSFCASUtilitiesTests/LinkedListStreamTests.swift
+++ b/Tests/TSFCASUtilitiesTests/LinkedListStreamTests.swift
@@ -1,0 +1,184 @@
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See http://swift.org/LICENSE.txt for license information
+// See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+import XCTest
+
+import TSFCAS
+import TSFCASUtilities
+
+import TSCBasic
+import TSCUtility
+
+class LinkedListStreamTests: XCTestCase {
+    let group = LLBMakeDefaultDispatchGroup()
+
+    func testSingleLine() throws {
+        let db = LLBInMemoryCASDatabase(group: group)
+        let ctx = Context()
+
+        var writer = LLBLinkedListStreamWriter(db)
+
+        writer.append(data: LLBByteBuffer.init(string: "hello, world!"), ctx)
+
+        let reader = LLBLinkedListStreamReader(db)
+
+        let latestID = try writer.latestID!.wait()
+
+        var contentRead = false
+        try reader.read(id: latestID, ctx) { (channel, data) -> Bool in
+            let stringData = String(data: Data(data.readableBytesView), encoding: .utf8)
+            XCTAssertEqual(stringData, "hello, world!")
+            contentRead = true
+            return true
+        }.wait()
+
+        XCTAssertTrue(contentRead)
+    }
+
+    func testStreamSingleChannel() throws {
+        let db = LLBInMemoryCASDatabase(group: group)
+        let ctx = Context()
+
+        let writeStream = Array(0...20).map { "Stream line \($0)" }
+
+        var writer = LLBLinkedListStreamWriter(db)
+
+        for block in writeStream {
+            writer.append(data: LLBByteBuffer.init(string: block), ctx)
+        }
+
+        let reader = LLBLinkedListStreamReader(db)
+
+        let latestID = try writer.latestID!.wait()
+
+        var readStream = [String]()
+
+        try reader.read(id: latestID, ctx) { (channel, data) -> Bool in
+            guard let block = String(data: Data(data.readableBytesView), encoding: .utf8) else {
+                XCTFail("Could not read string from stream")
+                return false
+            }
+            readStream.append(block)
+            return true
+        }.wait()
+
+        XCTAssertEqual(readStream, writeStream)
+    }
+
+    func testStreamMultiChannel() throws {
+        let db = LLBInMemoryCASDatabase(group: group)
+        let ctx = Context()
+
+        let writeStream: [(UInt8, String)] = Array(0...20).map { ($0 % 4, "Stream line \($0)") }
+
+        var writer = LLBLinkedListStreamWriter(db)
+
+        for (channel, block) in writeStream {
+            writer.append(data: LLBByteBuffer.init(string: block), channel: channel, ctx)
+        }
+
+        let reader = LLBLinkedListStreamReader(db)
+
+        let latestID = try writer.latestID!.wait()
+
+        var readStream = [String]()
+
+        try reader.read(id: latestID, channels: [0, 1], ctx) { (channel, data) -> Bool in
+            guard let block = String(data: Data(data.readableBytesView), encoding: .utf8) else {
+                XCTFail("Could not read string from stream")
+                return false
+            }
+            readStream.append(block)
+            return true
+        }.wait()
+
+        let filteredWriteStream = writeStream.filter { $0.0 <= 1 }.map { $0.1 }
+
+        XCTAssertEqual(readStream, filteredWriteStream)
+    }
+
+    func testStreamReadLimit() throws {
+        let db = LLBInMemoryCASDatabase(group: group)
+        let ctx = Context()
+
+        let writeStream = Array(0...20).map { "Stream line \($0)" }
+
+        var writer = LLBLinkedListStreamWriter(db)
+
+        for block in writeStream {
+            writer.append(data: LLBByteBuffer.init(string: block), ctx)
+        }
+
+        let reader = LLBLinkedListStreamReader(db)
+
+        let latestID = try writer.latestID!.wait()
+
+        var readStream = [String]()
+
+        var stopped = false
+        try reader.read(id: latestID, ctx) { (channel, data) -> Bool in
+            // Read only 5 elements
+            if readStream.count == 5 {
+                stopped = true
+                return false
+            }
+            guard !stopped else {
+                XCTFail("Requested to stop but kept receiving data")
+                return false
+            }
+
+            guard let block = String(data: Data(data.readableBytesView), encoding: .utf8) else {
+                XCTFail("Could not read string from stream")
+                return false
+            }
+            readStream.append(block)
+            return true
+        }.wait()
+
+        XCTAssertEqual(readStream, Array(writeStream.prefix(5)))
+    }
+
+
+    func testStreamFromPreviousState() throws {
+        let db = LLBInMemoryCASDatabase(group: group)
+        let ctx = Context()
+
+        let writeStream = Array(0...20).map { "Stream line \($0)" }
+
+        var writer = LLBLinkedListStreamWriter(db)
+
+        for block in writeStream {
+            writer.append(data: LLBByteBuffer.init(string: block), ctx)
+        }
+
+        let startMarker = try writer.latestID!.wait()
+
+        let writeStream2 = Array(21...40).map { "Stream line \($0)" }
+
+        for block in writeStream2 {
+            writer.append(data: LLBByteBuffer.init(string: block), ctx)
+        }
+
+        let reader = LLBLinkedListStreamReader(db)
+
+        let latestID = try writer.latestID!.wait()
+
+        var readStream = [String]()
+
+        try reader.read(id: latestID, lastReadID: startMarker, ctx) { (channel, data) -> Bool in
+            guard let block = String(data: Data(data.readableBytesView), encoding: .utf8) else {
+                XCTFail("Could not read string from stream")
+                return false
+            }
+            readStream.append(block)
+            return true
+        }.wait()
+
+        XCTAssertEqual(readStream, writeStream2)
+    }
+}


### PR DESCRIPTION
Includes a naïve implementation using linked list, but should provide enough infrastructure to start implementing a more sophisticated algorithm.