### PR TITLE
Upgrade to protoc 3.15

### DIFF
--- a/Sources/TSFCAS/Generated/CASProtocol/cas_object.pb.swift
+++ b/Sources/TSFCAS/Generated/CASProtocol/cas_object.pb.swift
@@ -37,7 +37,7 @@ public struct LLBPBCASObject {
 
   public var refs: [LLBDataID] = []
 
-  public var data: Data = SwiftProtobuf.Internal.emptyData
+  public var data: Data = Data()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -55,9 +55,12 @@ extension LLBPBCASObject: SwiftProtobuf.Message, SwiftProtobuf._MessageImplement
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try decoder.decodeRepeatedMessageField(value: &self.refs)
-      case 2: try decoder.decodeSingularBytesField(value: &self.data)
+      case 1: try { try decoder.decodeRepeatedMessageField(value: &self.refs) }()
+      case 2: try { try decoder.decodeSingularBytesField(value: &self.data) }()
       default: break
       }
     }

--- a/Sources/TSFCAS/Generated/CASProtocol/data_id.pb.swift
+++ b/Sources/TSFCAS/Generated/CASProtocol/data_id.pb.swift
@@ -37,7 +37,7 @@ public struct LLBDataID {
   // methods supported on all messages.
 
   //// The bytes containing the digest of the contents store in the CAS.
-  public var bytes: Data = SwiftProtobuf.Internal.emptyData
+  public var bytes: Data = Data()
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
@@ -54,8 +54,11 @@ extension LLBDataID: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementation
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every case branch when no optimizations are
+      // enabled. https://github.com/apple/swift-protobuf/issues/1034
       switch fieldNumber {
-      case 1: try decoder.decodeSingularBytesField(value: &self.bytes)
+      case 1: try { try decoder.decodeSingularBytesField(value: &self.bytes) }()
       default: break
       }
     }

--- a/Utilities/build_proto_toolchain.sh
+++ b/Utilities/build_proto_toolchain.sh
@@ -8,8 +8,8 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-PROTOC_ZIP=protoc-3.12.2-osx-x86_64.zip
-PROTOC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v3.12.2/$PROTOC_ZIP"
+PROTOC_ZIP=protoc-3.15.0-osx-x86_64.zip
+PROTOC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v3.15.0/$PROTOC_ZIP"
 
 UTILITIES_DIR="$(dirname "$0")"
 TOOLS_DIR="$UTILITIES_DIR/tools"


### PR DESCRIPTION
This was released eight months ago, and allows proto3 files to have `optional` fields without requiring the `--experimental_allow_proto3_optional` flag.