### PR TITLE
Conditionally initialize POSIX file details

### DIFF
--- a/Sources/TSFCASFileTree/FilesystemObject.swift
+++ b/Sources/TSFCASFileTree/FilesystemObject.swift
@@ -89,13 +89,19 @@ extension LLBPosixFileDetails {
         group = UInt32(exactly: info.st_gid) ?? 0
     }
 
-    init(from info: LLBFileInfo) {
+    init?(from info: LLBFileInfo) {
+        guard info.hasPosixDetails else {
+            return nil
+        }
         var posixDetails = info.posixDetails
         posixDetails.mode &= 0o7777
         self = posixDetails
     }
 
-    init(from info: LLBDirectoryEntry) {
+    init?(from info: LLBDirectoryEntry) {
+        guard info.hasPosixDetails else {
+            return nil
+        }
         var posixDetails = info.posixDetails
         posixDetails.mode &= 0o7777
         self = posixDetails

--- a/Sources/TSFCASFileTree/Internal/FileTreeParser.swift
+++ b/Sources/TSFCASFileTree/Internal/FileTreeParser.swift
@@ -128,7 +128,7 @@ struct CASFileTreeParser {
 
     func parseDirectory(id: LLBDataID, path: AbsolutePath, casObject: LLBCASObject) throws -> (LLBFilesystemObject, [AnnotatedCASTreeChunk]) {
 
-        let posixDetails: LLBPosixFileDetails
+        let posixDetails: LLBPosixFileDetails?
         let dirContents: [LLBDirectoryEntry]
         let dirInfo = try LLBFileInfo.deserialize(from: casObject.data)
         guard dirInfo.type == .directory else {


### PR DESCRIPTION
 * This is a follow-up PR to #18 
 * Allow CAS trees to store POSIX permission information.
