### PR TITLE
Remove deprecated OrderManager initializer

### DIFF
--- a/Sources/TSFFutures/OrderManager.swift
+++ b/Sources/TSFFutures/OrderManager.swift
@@ -70,20 +70,6 @@ public class LLBOrderManager {
     case orderManagerReset(file: String, line: Int)
     }
 
-    @available(*, deprecated, message: "Use init(on:timeout:)")
-    public init(timeout: DispatchTimeInterval = .seconds(60)) {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        self.groupDesignator = GroupDesignator.managedGroup(group)
-        self.timeout = timeout
-        restartInactivityTimer()
-        cancelTimer.setEventHandler { [weak self] in
-            guard let self = self else { return }
-            _ = self.reset()
-            self.cancelTimer.cancel()
-        }
-        cancelTimer.resume()
-    }
-
     public init(on loop: EventLoop, timeout: DispatchTimeInterval = .seconds(60)) {
         self.groupDesignator = GroupDesignator.externallySuppliedGroup(loop)
         self.timeout = timeout

--- a/Tests/TSFFuturesTests/OrderManagerTests.swift
+++ b/Tests/TSFFuturesTests/OrderManagerTests.swift
@@ -10,11 +10,6 @@ import TSFFutures
 
 class OrderManagerTests: XCTestCase {
 
-    func testOrderManagerWithGroup() throws {
-        let manager = LLBOrderManager()
-        try manager.reset().wait()
-    }
-
     func testOrderManagerWithLoop() throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer {


### PR DESCRIPTION
This is the cause of the only build warning in this package, and as far as I can tell, it's _only_ used by the test.