### PR TITLE
Fix cross-platform compatibility

### DIFF
--- a/Sources/TSFCASFileTree/Internal/ConcurrentFilesystemScanner.swift
+++ b/Sources/TSFCASFileTree/Internal/ConcurrentFilesystemScanner.swift
@@ -399,7 +399,9 @@ class FilesystemDirectoryIterator: IteratorProtocol {
                 break
             }
 
-            guard let filename = entry.pointee.name else {
+            guard let filename: String = withUnsafeBytes(of: &entry.pointee.d_name, { ptr in
+                String(validatingUTF8: ptr.bindMemory(to: CChar.self).baseAddress!)
+            }) else {
                 // Not an UTF-8-convertible name. Ignore it with prejudice.
                 continue
             }


### PR DESCRIPTION
 * Allow compiling under Linux with 5.5 toolchain without errors. Previous error:
```
Internal/ConcurrentFilesystemScanner.swift:402:48: error: type of expression is ambiguous without more context
                 guard let filename = entry.pointee.name else {
```