### PR TITLE
fix ByteBuffer index use

### DIFF
--- a/Sources/TSFCAS/DataID.swift
+++ b/Sources/TSFCAS/DataID.swift
@@ -142,7 +142,7 @@ extension LLBDataID: LLBSerializable {
 
     @inlinable
     public init(from rawBytes: LLBByteBuffer) throws {
-        guard let bytes = rawBytes.getBytes(at: 0, length: rawBytes.readableBytes), let dataId = LLBDataID(bytes: bytes) else {
+        guard let dataId = LLBDataID(bytes: Array(buffer: rawBytes)[...]) else {
             throw LLBDataIDSliceError.decoding("from slice of size \(rawBytes.readableBytes)")
         }
         self = dataId

--- a/Sources/TSFCAS/Implementations/FileBackedCASDatabase.swift
+++ b/Sources/TSFCAS/Implementations/FileBackedCASDatabase.swift
@@ -88,10 +88,7 @@ public final class LLBFileBackedCASDatabase: LLBCASDatabase {
         let dataFile = fileName(for: id, prefix: .data)
 
         let refsBytes: LLBFuture<[UInt8]> = readFile(file: refsFile).map { refsData in
-            if let bytes = refsData.getBytes(at: 0, length: refsData.readableBytes) {
-                return bytes
-            }
-            return []
+            return Array(buffer: refsData)
         }
 
         let refs = refsBytes.flatMapThrowing {

--- a/Sources/TSFCAS/Object.swift
+++ b/Sources/TSFCAS/Object.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 import TSFUtility
+import NIOFoundationCompat
 
 
 // MARK:- CASObject Definition -
@@ -61,7 +62,7 @@ public extension LLBCASObject {
     func toData() throws -> Data {
         var pb = LLBPBCASObject()
         pb.refs = self.refs
-        pb.data = Data(self.data.getBytes(at: 0, length: self.data.readableBytes)!)
+        pb.data = Data(buffer: self.data)
         return try pb.serializedData()
     }
 }

--- a/Tests/TSFCASFileTreeTests/CASBlobTests.swift
+++ b/Tests/TSFCASFileTreeTests/CASBlobTests.swift
@@ -52,7 +52,7 @@ class CASBlobTests: XCTestCase {
         for testRange in [0 ..< 0, 0 ..< 1, 0 ..< contents.count, 10 ..< 20, 20 ..< 128, 128 ..< 512] {
 
             let blobRange = try blob.read(range: testRange, ctx).wait()
-            let bytes: [UInt8] = LLBByteBuffer(blobRange).getBytes(at: 0, length: testRange.count)!
+            let bytes: [UInt8] = Array(LLBByteBuffer(blobRange).readableBytesView[..< testRange.count])
             XCTAssertEqual(ArraySlice(bytes), contents[testRange])
         }
     }

--- a/Tests/TSFCASTests/InMemoryCASDatabaseTests.swift
+++ b/Tests/TSFCASTests/InMemoryCASDatabaseTests.swift
@@ -34,7 +34,7 @@ class InMemoryCASDatabaseTests: XCTestCase {
         XCTAssertEqual(id2, LLBDataID(string: "0~udZrZzFHJr8uovWT5dOWtKz95ZqKi-vBkpiH0mJfjM4="))
         XCTAssertEqual(obj2.size, 3)
         XCTAssertEqual(obj2.refs, [id1])
-        XCTAssertEqual(obj2.data.getBytes(at: 0, length: obj2.data.readableBytes), [4, 5, 6])
+        XCTAssertEqual(Array(obj2.data.readableBytesView[..< obj2.data.readableBytes]), [4, 5, 6])
         XCTAssertEqual(try db.contains(id1, ctx).wait(), true)
 
         // Check contains on a missing object.


### PR DESCRIPTION
The existing code is unnecessary complex and assumes that the buffer's readerIndex is 0 which cannot be assumed because it comes from elsewhere.