### PR TITLE
Fix inconsistencies in handling of LLBPosixFileDetails

### DIFF
--- a/Sources/TSFCASFileTree/FileTree.swift
+++ b/Sources/TSFCASFileTree/FileTree.swift
@@ -165,7 +165,7 @@ public final class LLBCASFileTree {
     public func lookup(_ name: String) -> (id: LLBDataID, info: LLBDirectoryEntry)? {
 
         guard name != "." else {
-            let entry = LLBDirectoryEntry(name: ".", type: .directory, size: aggregateSize)
+            let entry = LLBDirectoryEntry(name: ".", type: .directory, size: aggregateSize, posixDetails: self.posixDetails)
             return (id: self.id, info: entry)
         }
 
@@ -415,7 +415,8 @@ public final class LLBCASFileTree {
         for component in path.components.dropFirst().reversed() {
             rerootedTree = rerootedTree.flatMap { tree in
                 return LLBCASFileTree.create(files: [
-                    .init(info: LLBDirectoryEntry(name: component, type: .directory, size: tree.aggregateSize),
+                    .init(info: LLBDirectoryEntry(name: component, type: .directory, size: tree.aggregateSize,
+                                                  posixDetails: tree.posixDetails),
                           id: tree.id)], in: db, posixDetails: self.posixDetails, ctx)
             }
         }

--- a/Sources/TSFCASFileTree/FileTreeImport.swift
+++ b/Sources/TSFCASFileTree/FileTreeImport.swift
@@ -1311,6 +1311,8 @@ extension LLBFileInfo {
     mutating func update(posixDetails: LLBPosixFileDetails, options: LLBCASFileTree.ImportOptions?) {
         if let details = posixDetails.normalized(expectedMode: type.expectedPosixMode, options: options) {
             self.posixDetails = details
+        } else {
+            self.clearPosixDetails()
         }
     }
 
@@ -1318,9 +1320,11 @@ extension LLBFileInfo {
 
 extension LLBDirectoryEntry {
 
-    mutating func update(posixDetails: LLBPosixFileDetails, options: LLBCASFileTree.ImportOptions?) {
+    public mutating func update(posixDetails: LLBPosixFileDetails, options: LLBCASFileTree.ImportOptions?) {
         if let details = posixDetails.normalized(expectedMode: type.expectedPosixMode, options: options) {
             self.posixDetails = details
+        } else {
+            self.clearPosixDetails()
         }
     }
 


### PR DESCRIPTION
For directory entries, the LLBPosixFileDetails are stored in both the LLBCASFileTree and the corresponding LLBDirectoryEntry, and this change fixes a few places where they were not kept consistent.

Also, the LLBPosixFileDetails are stored as an optional field of LLBDirectoryEntry, where a nil value indicates that the entry has the default value (which depends on the file type). If the default value is specified explicitly but then normalized to nil, there were a few places where the optional field needs to be cleared.