### PR TITLE
Require swift-tools-support-core version 0.2.7

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "b7667f3e266af621e5cc9c77e74cacd8e8c00cb4",
-          "version": "0.2.5"
+          "revision": "4f07be3dc201f6e2ee85b6942d0c220a16926811",
+          "version": "0.2.7"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.8.0"),
-        .package(url: "https://github.com/apple/swift-tools-support-core.git", from: "0.2.3"),
+        .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.2.7")),
     ],
     targets: [
         // BLAKE3 hash support


### PR DESCRIPTION
swift-tools-support-core PR #345 is needed to build with Xcode 14. The 0.2.7 tag includes that fix, so require that version. (Note that the other tags from around the same point, e.g., 0.2.6 and 0.3.0, have an additional requirement for macOS 10.13, which causes trouble unless all transitive dependencies raise their minimum macOS version.)