### PR TITLE
Add missing imports for Swift 6

### DIFF
--- a/Sources/TSFCAS/DataID.swift
+++ b/Sources/TSFCAS/DataID.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+import NIOCore
 import TSCBasic
 import TSFUtility
 

--- a/Sources/TSFCAS/Database.swift
+++ b/Sources/TSFCAS/Database.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+import NIOCore
 import TSCUtility
 
 @_exported import TSFFutures

--- a/Sources/TSFCAS/DatabaseSpec.swift
+++ b/Sources/TSFCAS/DatabaseSpec.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+import NIOCore
 import TSFFutures
 
 

--- a/Sources/TSFCAS/Implementations/Blake3DataID.swift
+++ b/Sources/TSFCAS/Implementations/Blake3DataID.swift
@@ -8,6 +8,7 @@
 
 
 import CBLAKE3
+import NIOCore
 import TSFUtility
 
 

--- a/Sources/TSFCAS/Implementations/InMemoryCASDatabase.swift
+++ b/Sources/TSFCAS/Implementations/InMemoryCASDatabase.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+import NIOCore
 import NIOConcurrencyHelpers
 
 import TSCUtility

--- a/Sources/TSFCAS/Object.swift
+++ b/Sources/TSFCAS/Object.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 import TSFUtility
+import NIOCore
 import NIOFoundationCompat
 
 

--- a/Sources/TSFCASFileTree/CASBlob.swift
+++ b/Sources/TSFCASFileTree/CASBlob.swift
@@ -6,8 +6,8 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+import NIOCore
 import TSCUtility
-
 import TSFCAS
 import TSFFutures
 import TSFUtility

--- a/Sources/TSFCASFileTree/CASFSClient.swift
+++ b/Sources/TSFCASFileTree/CASFSClient.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+import NIOCore
 import TSFCAS
 import TSCBasic
 import TSCUtility

--- a/Sources/TSFCASFileTree/ConcurrentFileTreeWalker.swift
+++ b/Sources/TSFCASFileTree/ConcurrentFileTreeWalker.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+import NIOCore
 import NIOConcurrencyHelpers
 import TSCBasic
 import TSCUtility

--- a/Sources/TSFCASFileTree/DeclFileTree.swift
+++ b/Sources/TSFCASFileTree/DeclFileTree.swift
@@ -6,8 +6,8 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+import NIOCore
 import TSCUtility
-
 import TSFCAS
 
 

--- a/Sources/TSFCASFileTree/FileInfo.swift
+++ b/Sources/TSFCASFileTree/FileInfo.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+import NIOCore
+import SwiftProtobuf
 
 extension LLBFileInfo: LLBSerializable {
     /// Decode the given block back into a message.

--- a/Sources/TSFCASFileTree/FileTree.swift
+++ b/Sources/TSFCASFileTree/FileTree.swift
@@ -9,6 +9,7 @@
 import Dispatch
 import Foundation
 
+import NIOCore
 import TSCBasic
 import TSCUtility
 

--- a/Sources/TSFCASFileTree/FileTreeExport.swift
+++ b/Sources/TSFCASFileTree/FileTreeExport.swift
@@ -9,6 +9,7 @@
 import Atomics
 import Foundation
 
+import NIOCore
 import NIOConcurrencyHelpers
 import TSCBasic
 import TSCUtility

--- a/Sources/TSFCASUtilities/BufferedStreamWriter.swift
+++ b/Sources/TSFCASUtilities/BufferedStreamWriter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NIOCore
 import NIOConcurrencyHelpers
 import TSCUtility
 import TSFCAS

--- a/Sources/TSFCASUtilities/LinkedListStream.swift
+++ b/Sources/TSFCASUtilities/LinkedListStream.swift
@@ -6,6 +6,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+import NIOCore
 import TSCUtility
 import TSFCAS
 import TSFCASFileTree

--- a/Sources/TSFCASUtilities/StreamReader.swift
+++ b/Sources/TSFCASUtilities/StreamReader.swift
@@ -6,6 +6,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+import NIOCore
 import TSCUtility
 import TSFCAS
 import TSFCASFileTree

--- a/Sources/TSFFutures/BatchingFutureOperationQueue.swift
+++ b/Sources/TSFFutures/BatchingFutureOperationQueue.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+import NIOCore
 import TSCUtility
 
 

--- a/Sources/TSFFutures/CancellableFuture.swift
+++ b/Sources/TSFFutures/CancellableFuture.swift
@@ -6,6 +6,7 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+import NIOCore
 
 /// A construct which expresses operations which can be asynchronously
 /// cancelled. The cancellation is not guaranteed and no ordering guarantees

--- a/Sources/TSFFutures/CancellablePromise.swift
+++ b/Sources/TSFFutures/CancellablePromise.swift
@@ -7,6 +7,7 @@
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
 import Atomics
+import NIOCore
 import NIOConcurrencyHelpers
 
 

--- a/Sources/TSFFutures/EventualResultsCache.swift
+++ b/Sources/TSFFutures/EventualResultsCache.swift
@@ -6,6 +6,8 @@
 // See http://swift.org/LICENSE.txt for license information
 // See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
+import NIOCore
+import NIOConcurrencyHelpers
 
 /// Cache of keys to eventually obtainable values.
 ///

--- a/Sources/TSFFutures/FutureDeduplicator.swift
+++ b/Sources/TSFFutures/FutureDeduplicator.swift
@@ -8,6 +8,7 @@
 
 import Dispatch
 
+import NIOCore
 import NIOConcurrencyHelpers
 
 

--- a/Sources/TSFUtility/FastData.swift
+++ b/Sources/TSFUtility/FastData.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+import NIOCore
 
 /// Something that exposes working withContiguousStorage
 public enum LLBFastData {

--- a/Sources/TSFUtility/FutureFileSystem.swift
+++ b/Sources/TSFUtility/FutureFileSystem.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+import NIOCore
 import TSCBasic
 import TSFFutures
 

--- a/Sources/TSFUtility/Serializable.swift
+++ b/Sources/TSFUtility/Serializable.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+import NIOCore
 
 /// Serializable protocol describes a structure that can be serialized
 /// into a buffer of bytes, and deserialized back from the buffer of bytes.


### PR DESCRIPTION
Missing imports are going to be a problem in Swift 6. We should add the missing imports :)