### PR TITLE
Upgrade to protoc 21.10

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -11,12 +11,21 @@
         }
       },
       {
+        "package": "swift-collections",
+        "repositoryURL": "https://github.com/apple/swift-collections.git",
+        "state": {
+          "branch": null,
+          "revision": "f504716c27d2e5d4144fa4794b12129301d17729",
+          "version": "1.0.3"
+        }
+      },
+      {
         "package": "swift-nio",
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "ece5057615d1bee848341eceafdf04ca54d60177",
-          "version": "2.41.0"
+          "revision": "e855380cb5234e96b760d93e0bfdc403e381e928",
+          "version": "2.45.0"
         }
       },
       {
@@ -24,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "1f62db409f2c9b0223a3f68567b4a01333aae778",
-          "version": "1.17.0"
+          "revision": "ab3a58b7209a17d781c0d1dbb3e1ff3da306bae8",
+          "version": "1.20.3"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
-        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.8.0"),
+        .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.20.3"),
         .package(url: "https://github.com/apple/swift-tools-support-core.git", .upToNextMinor(from: "0.2.7")),
     ],
     targets: [

--- a/Sources/TSFCAS/Generated/CASProtocol/cas_object.pb.swift
+++ b/Sources/TSFCAS/Generated/CASProtocol/cas_object.pb.swift
@@ -44,6 +44,10 @@ public struct LLBPBCASObject {
   public init() {}
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension LLBPBCASObject: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 extension LLBPBCASObject: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Sources/TSFCAS/Generated/CASProtocol/data_id.pb.swift
+++ b/Sources/TSFCAS/Generated/CASProtocol/data_id.pb.swift
@@ -44,6 +44,10 @@ public struct LLBDataID {
   public init() {}
 }
 
+#if swift(>=5.5) && canImport(_Concurrency)
+extension LLBDataID: @unchecked Sendable {}
+#endif  // swift(>=5.5) && canImport(_Concurrency)
+
 // MARK: - Code below here is support for the SwiftProtobuf runtime.
 
 extension LLBDataID: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {

--- a/Sources/TSFCAS/Implementations/InMemoryCASDatabase.swift
+++ b/Sources/TSFCAS/Implementations/InMemoryCASDatabase.swift
@@ -25,7 +25,7 @@ public final class LLBInMemoryCASDatabase {
     public var group: LLBFuturesDispatchGroup
 
     /// The lock protecting content.
-    let lock = NIOConcurrencyHelpers.Lock()
+    let lock = NIOConcurrencyHelpers.NIOLock()
 
     /// The total number of data bytes in the database (this does not include the size of refs).
     public var totalDataBytes: Int {

--- a/Sources/TSFCASFileTree/ConcurrentFileTreeWalker.swift
+++ b/Sources/TSFCASFileTree/ConcurrentFileTreeWalker.swift
@@ -72,7 +72,7 @@ public class LLBConcurrentFileTreeWalker: RetrieveChildrenProtocol {
     }
 
     public class ScanResult {
-        let lock = NIOConcurrencyHelpers.Lock()
+        let lock = NIOConcurrencyHelpers.NIOLock()
         var collectedArguments = [FilterArgument]()
 
         public func reapResult() -> [FilterArgument] {

--- a/Sources/TSFCASFileTree/FileTreeImport.swift
+++ b/Sources/TSFCASFileTree/FileTreeImport.swift
@@ -531,7 +531,7 @@ private final class CASTreeImport {
                 return loop.makeSucceededFuture(firstFile.id)
             }
 
-            let udpLock = NIOConcurrencyHelpers.Lock()
+            let udpLock = NIOConcurrencyHelpers.NIOLock()
             var uploadedDirectoryPaths_ = [AbsolutePath: LLBFuture<(LLBDataID, LLBDirectoryEntry)?>]()
 
             // Now we have to add all the directories; we do so serially and in

--- a/Sources/TSFCASFileTree/Internal/ConcurrentFilesystemScanner.swift
+++ b/Sources/TSFCASFileTree/Internal/ConcurrentFilesystemScanner.swift
@@ -316,7 +316,7 @@ class FilesystemDirectoryIterator: IteratorProtocol {
     public typealias Element = ([NameAndType], hasMoreEntries: Bool)
 
     fileprivate let path: AbsolutePath
-    private let dirLock = NIOConcurrencyHelpers.Lock()
+    private let dirLock = NIOConcurrencyHelpers.NIOLock()
 #if canImport(Darwin)
     private var dir: UnsafeMutablePointer<DIR>!
 #elseif os(Linux)

--- a/Sources/TSFCASUtilities/BufferedStreamWriter.swift
+++ b/Sources/TSFCASUtilities/BufferedStreamWriter.swift
@@ -11,7 +11,7 @@ fileprivate extension LLBByteBuffer {
 /// Stream writer that buffers data before ingesting it into the CAS database.
 public class LLBBufferedStreamWriter {
     private let bufferSize: Int
-    private let lock = NIOConcurrencyHelpers.Lock()
+    private let lock = NIOConcurrencyHelpers.NIOLock()
     private var outputWriter: LLBLinkedListStreamWriter
     private var currentBuffer: LLBByteBuffer
     private var currentBufferedChannel: UInt8? = nil

--- a/Sources/TSFFutures/Canceller.swift
+++ b/Sources/TSFFutures/Canceller.swift
@@ -15,7 +15,7 @@ public protocol LLBCancelProtocol {
 /// An object serving as a cancellation handler which can
 /// be supplied a cancellation procedure much later in its lifetime.
 public final class LLBCanceller {
-    private let mutex_ = NIOConcurrencyHelpers.Lock()
+    private let mutex_ = NIOConcurrencyHelpers.NIOLock()
 
     /// Whether and why it was cancelled.
     private var finalReason_: FinalReason? = nil
@@ -112,7 +112,7 @@ extension LLBCanceller: LLBCancelProtocol { }
 
 /// Create a chain of single-purpose handlers.
 public final class LLBCancelHandlersChain: LLBCancelProtocol {
-    private let lock = NIOConcurrencyHelpers.Lock()
+    private let lock = NIOConcurrencyHelpers.NIOLock()
     private var head: LLBCancelProtocol?
     private var tail: LLBCancelProtocol?
 

--- a/Sources/TSFFutures/FutureDeduplicator.swift
+++ b/Sources/TSFFutures/FutureDeduplicator.swift
@@ -26,7 +26,7 @@ public class LLBFutureDeduplicator<Key: Hashable, Value> {
 
     /// Protect shared inFlightRequests.
     @usableFromInline
-    internal let lock = NIOConcurrencyHelpers.Lock()
+    internal let lock = NIOConcurrencyHelpers.NIOLock()
 
     /// The mapping of the keys currently being resolved.
     @usableFromInline

--- a/Sources/TSFFutures/FutureOperationQueue.swift
+++ b/Sources/TSFFutures/FutureOperationQueue.swift
@@ -33,7 +33,7 @@ public final class LLBFutureOperationQueue {
     private let maxConcurrentShares: Int
 
     /// Lock protecting state.
-    private let lock = NIOConcurrencyHelpers.Lock()
+    private let lock = NIOConcurrencyHelpers.NIOLock()
 
     /// The number of executing futures.
     private var numExecuting = 0

--- a/Sources/TSFFutures/OrderManager.swift
+++ b/Sources/TSFFutures/OrderManager.swift
@@ -45,7 +45,7 @@ public class LLBOrderManager {
     private let timeout: DispatchTimeInterval
 
     private typealias WaitListElement = (order: Int, promise: LLBPromise<Void>, file: String, line: Int)
-    private let lock = NIOConcurrencyHelpers.Lock()
+    private let lock = NIOConcurrencyHelpers.NIOLock()
     private var waitlist = [WaitListElement]()
     private var nextToRun = 1
 

--- a/Tests/TSFFuturesTests/FutureOperationQueueTests.swift
+++ b/Tests/TSFFuturesTests/FutureOperationQueueTests.swift
@@ -78,7 +78,7 @@ class FutureOperationQueueTests: XCTestCase {
 
         let atomic = ManagedAtomic(0)
         var futures: [LLBFuture<Bool>] = []
-        let lock = NIOConcurrencyHelpers.Lock()
+        let lock = NIOConcurrencyHelpers.NIOLock()
         DispatchQueue.concurrentPerform(iterations: 1_000) { i in
             let result = q.enqueue(on: group.next()) { () -> LLBFuture<Bool> in
                 // Check that we aren't executing more operations than we would want.

--- a/Utilities/build_proto_toolchain.sh
+++ b/Utilities/build_proto_toolchain.sh
@@ -8,8 +8,8 @@
 # See http://swift.org/LICENSE.txt for license information
 # See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
 
-PROTOC_ZIP=protoc-3.15.0-osx-x86_64.zip
-PROTOC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v3.15.0/$PROTOC_ZIP"
+PROTOC_ZIP=protoc-21.10-osx-universal_binary.zip
+PROTOC_URL="https://github.com/protocolbuffers/protobuf/releases/download/v21.10/$PROTOC_ZIP"
 
 UTILITIES_DIR="$(dirname "$0")"
 TOOLS_DIR="$UTILITIES_DIR/tools"


### PR DESCRIPTION
Note: Google changed the versioning scheme, so this is more like going from 3.15 to 3.21. This upgrade gets us proper Sendable conformance for protobuf types.