### PR TITLE
TSA is compatible with TSC 0.6.x

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/apple/swift-collections.git",
         "state": {
           "branch": null,
-          "revision": "937e904258d22af6e447a0b72c0bc67583ef64a2",
-          "version": "1.0.4"
+          "revision": "671108c96644956dddcd89dd59c203dcdb36cec7",
+          "version": "1.1.4"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/apple/swift-nio.git",
         "state": {
           "branch": null,
-          "revision": "4c4453b489cf76e6b3b0f300aba663eb78182fad",
-          "version": "2.70.0"
+          "revision": "f7dc3f527576c398709b017584392fb58592e7f5",
+          "version": "2.75.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/apple/swift-protobuf.git",
         "state": {
           "branch": null,
-          "revision": "564597ad2fe2513a94dd8f3ba27ea2ff4be3cb37",
-          "version": "1.28.0"
+          "revision": "ebc7251dd5b37f627c93698e4374084d98409633",
+          "version": "1.28.2"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/apple/swift-system.git",
         "state": {
           "branch": null,
-          "revision": "d2ba781702a1d8285419c15ee62fd734a9437ff5",
-          "version": "1.3.2"
+          "revision": "c8a44d836fe7913603e246acab7c528c2e780168",
+          "version": "1.4.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/apple/swift-tools-support-core.git",
         "state": {
           "branch": null,
-          "revision": "62ba237eda0f7ef15264ef3468ae4cda1866b7c8",
-          "version": "0.5.3"
+          "revision": "3b13e439a341bbbfe0f710c7d1be37221745ef1a",
+          "version": "0.6.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.68.0"),
         .package(url: "https://github.com/apple/swift-protobuf.git", from: "1.28.0"),
-        .package(url: "https://github.com/apple/swift-tools-support-core.git", "0.2.7" ..< "0.6.0"),
+        .package(url: "https://github.com/apple/swift-tools-support-core.git", "0.2.7" ..< "0.7.0"),
     ],
     targets: [
         // BLAKE3 hash support


### PR DESCRIPTION
TSA @ `main` is compatible with TSC 0.6.x. Given that TSA is 0.x we can take this without SemVer repercussions. Just to be sure, this should be tagged as `0.12.0` and now `0.11.x`.